### PR TITLE
feat: Add behaviour if no IntersectionObserver is available

### DIFF
--- a/src/__tests__/useIntersection-test.ts
+++ b/src/__tests__/useIntersection-test.ts
@@ -1,4 +1,3 @@
-import { expect } from '@jest/globals';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useIntersection } from '../useIntersection';
 

--- a/src/__tests__/useIntersection-test.ts
+++ b/src/__tests__/useIntersection-test.ts
@@ -1,3 +1,4 @@
+import { expect } from '@jest/globals';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useIntersection } from '../useIntersection';
 
@@ -73,5 +74,13 @@ describe('useIntersection', () => {
 		unmount();
 
 		expect(disconnect).toHaveBeenCalled();
+	});
+
+	it('allow intersecting if no IntersectionObserver is available', () => {
+		window.IntersectionObserver = undefined as never
+		const ref = { current: document.createElement('div') };
+		const { result } = renderHook(() => useIntersection({ ref }));
+
+		expect(result.current).toBeTruthy()
 	});
 });

--- a/src/useIntersection.ts
+++ b/src/useIntersection.ts
@@ -25,6 +25,8 @@ export const useIntersection = <T extends HTMLElement>({
 	const [intersecting, setIntersecting] = useState(false);
 	if (IntersectionObserver === undefined) {
 		!intersecting && setIntersecting(true);
+
+		return { intersecting }
 	}
 
 	/**


### PR DESCRIPTION
This early exit avoids going through complete code and instantiating a non-existent IntersectionObserver.