### PR TITLE
refactor: Create & keep the element-reference within the hook

### DIFF
--- a/src/__tests__/useIntersection-test.ts
+++ b/src/__tests__/useIntersection-test.ts
@@ -29,35 +29,43 @@ describe('useIntersection', () => {
 
 	it('should observe element on mount', () => {
 		const { observe } = setUp();
-		const ref = { current: document.createElement('div') };
-		renderHook(() => useIntersection({ ref }));
+		const element =  document.createElement('div')
+		const { result } = renderHook(() => useIntersection({}));
 
-		expect(observe).toHaveBeenCalledWith(ref.current);
+		act(() => {
+			result.current.elementRef(element)
+		})
+
+		expect(observe).toHaveBeenCalledWith(element);
 	});
 
 	it('should unobserve element when intersecting and triggerOnce is true', () => {
 		const { unobserve } = setUp();
-		const ref = { current: document.createElement('div') };
-		renderHook(() => useIntersection({ ref, triggerOnce: true }));
+		const element =  document.createElement('div')
+		const { result } = renderHook(() => useIntersection({ triggerOnce: true }));
 
 		act(() => {
+			result.current.elementRef(element)
+
 			observerMock.mock.calls[0][0](
-				[{ isIntersecting: true, target: ref.current }],
+				[{ isIntersecting: true, target: element }],
 				observerMock.mock.instances[0]
 			);
 		});
 
-		expect(unobserve).toHaveBeenCalledWith(ref.current);
+		expect(unobserve).toHaveBeenCalledWith(element);
 	});
 
 	it('should not unobserve element when intersecting and triggerOnce is false', () => {
 		const { unobserve } = setUp();
-		const ref = { current: document.createElement('div') };
-		renderHook(() => useIntersection({ ref }));
+		const element =  document.createElement('div')
+		const { result } = renderHook(() => useIntersection({}));
 
 		act(() => {
+			result.current.elementRef(element)
+
 			observerMock.mock.calls[0][0](
-				[{ isIntersecting: true, target: ref.current }],
+				[{ isIntersecting: true, target: element }],
 				observerMock.mock.instances[0]
 			);
 		});
@@ -65,12 +73,13 @@ describe('useIntersection', () => {
 		expect(unobserve).not.toHaveBeenCalled();
 	});
 
-	it('should disconnect observer on unmount', () => {
+	it('disconnects the observer on destroying reference to the element', () => {
 		const { disconnect } = setUp();
-		const ref = { current: document.createElement('div') };
-		const { unmount } = renderHook(() => useIntersection({ ref }));
+		const { result } = renderHook(() => useIntersection({}));
 
-		unmount();
+		act(() => {
+			result.current.elementRef(null)
+		})
 
 		expect(disconnect).toHaveBeenCalled();
 	});


### PR DESCRIPTION
My first (naive) approach, creating the reference for the element within the hook.

My motivation behind it was...
- The aspect with the empty `NodeRef` and
- whenever I use `useEffect`, I remember [David Khourshid's](https://www.youtube.com/watch?v=bGzanfKVFeU) video and ask myself whether there're other, perhaps better options.